### PR TITLE
Remove TinyMCE branding

### DIFF
--- a/web/funclib/editor.mas
+++ b/web/funclib/editor.mas
@@ -19,6 +19,7 @@
 				browser_spellcheck : true,
 				relative_urls      : false,
 				remove_script_host : false,
+				branding           : false,
 				document_base_url  : "https://www.tabroom.com/"
 				<% $height_line %>
 			});
@@ -43,6 +44,7 @@
 				browser_spellcheck              : true,
 				relative_urls                   : false,
 				remove_script_host              : false,
+				branding                        : false,
 				document_base_url               : "https://www.tabroom.com/"
 				<% $height_line %>
 			});
@@ -70,6 +72,7 @@
 				browser_spellcheck              : true,
 				relative_urls                   : false,
 				remove_script_host              : false,
+				branding                        : false,
 				document_base_url               : "https://www.tabroom.com/"
 				<% $height_line %>
 			});


### PR DESCRIPTION
Community request to remove the TinyMCE branding from the editor window because it interferes with typing judge comments. TinyMCE is GPL, so I think already covered by the license in the repo. Maybe in theory should add an attribution line somewhere as well?

If I'm missing something here, just deny the PR and nuke the branch.