### PR TITLE
Congress speech check

### DIFF
--- a/web/setup/events/tabbing.mhtml
+++ b/web/setup/events/tabbing.mhtml
@@ -1241,6 +1241,23 @@
 						</span>
 					</div>
 				</label>
+
+				<label for="enforce_equal_speeches">
+					<div class="hover row fixedheight marno">
+						<span class="fivesixth ">
+							Require scorers to record equal numbers of speeches
+						</span>
+
+						<span class="sixth">
+							<& "/funclib/bool_switch.mas",
+								tag     => "enforce_equal_speeches",
+								value   => $event_settings{"enforce_equal_speeches"},
+								target  => $event,
+								smaller => 1,
+							&>
+						</span>
+					</div>
+				</label>
 %			}
 
 				<div class="row fixedheight">

--- a/web/user/judge/ballot.mhtml
+++ b/web/user/judge/ballot.mhtml
@@ -326,69 +326,72 @@
 		$min_ob_points = 0 unless $min_ob_points;
 		$max_ob_points = 6 unless $max_ob_points;
 
-        my @scores = $m->comp(
-            '/funclib/judge_scores.mas',
-            judge    => $judge,
-            timeslot => $round->timeslot,
-            tag      => "speech"
-        );
+		if ( (not defined $chair) && $event_settings{"enforce_equal_speeches"}) { 
 
-        foreach my $score (@scores) {
-            $entry_scores{$score->entryid}{$score->speech} = $score;
-			$entry_scores{$score->entryid}{"total"} += $score->value;
-			$entry_scores{$score->entryid}{"count"}++;
+			my @scores = $m->comp(
+				'/funclib/judge_scores.mas',
+				judge    => $judge,
+				timeslot => $round->timeslot,
+				tag      => "speech"
+			);
 
-        }
+			foreach my $score (@scores) {
+				$entry_scores{$score->entryid}{$score->speech} = $score;
+				$entry_scores{$score->entryid}{"total"} += $score->value;
+				$entry_scores{$score->entryid}{"count"}++;
 
-# Check to see if other judges have the same number of scores for each competitor		
-		my %other_entry_scores_count;
-
-		# Get other judges from panel
-		my @judges = $m->comp(
-			'/funclib/panel_judges.mas',
-			panel 	=> $panel
-		);
-
-		foreach my $other_judge (@judges) {
-			next if $other_judge == $judge;
-
-			# Get scores for this judge
-			my @other_scores = $m->comp(
-            	'/funclib/judge_scores.mas',
-            	judge    => $other_judge,
-            	timeslot => $round->timeslot,
-            	tag      => "speech"
-        	);
-			
-			# Count scores for each judge
-			foreach my $other_score (@other_scores) {
-				$other_entry_scores_count{$other_judge->id}{$other_score->entryid}++;
-				# This will create the entry for the current judge if the current judge has no score
-				$entry_scores{$other_score->entryid}{"count"} = 0 unless exists $entry_scores{$other_score->entryid}{"count"};
 			}
-		}
 
-		# Compare number of other judge scores to this judge
-		foreach my $entryid (keys %entry_scores) {
+			# Check to see if other judges have the same number of scores for each competitor		
+			my %other_entry_scores_count;
+
+			# Get other judges from panel
+			my @judges = $m->comp(
+				'/funclib/panel_judges.mas',
+				panel 	=> $panel
+			);
+
 			foreach my $other_judge (@judges) {
 				next if $other_judge == $judge;
-				if ($entry_scores{$entryid}{"count"} != $other_entry_scores_count{$other_judge->id}{$entryid}) {
-					
-					# Get judge name, student code, adjust scores
-					my $other_judge_name = $other_judge->first." ".$other_judge->last;
-					my $other_score = $other_entry_scores_count{$other_judge->id}{$entryid};
-					$other_score = 0 if $other_score == undef;
-					my $student_code;
-					foreach my $student (@panel_students) {
-						if ($student->entry == $entryid) {
-							$student_code = $student->code;
+
+				# Get scores for this judge
+				my @other_scores = $m->comp(
+					'/funclib/judge_scores.mas',
+					judge    => $other_judge,
+					timeslot => $round->timeslot,
+					tag      => "speech"
+				);
+				
+				# Count scores for each judge
+				foreach my $other_score (@other_scores) {
+					$other_entry_scores_count{$other_judge->id}{$other_score->entryid}++;
+					# This will create the entry for the current judge if the current judge has no score
+					$entry_scores{$other_score->entryid}{"count"} = 0 unless exists $entry_scores{$other_score->entryid}{"count"};
+				}
+			}
+
+			# Compare number of other judge scores to this judge
+			foreach my $entryid (keys %entry_scores) {
+				foreach my $other_judge (@judges) {
+					next if $other_judge == $judge;
+					if ($entry_scores{$entryid}{"count"} != $other_entry_scores_count{$other_judge->id}{$entryid}) {
+						
+						# Get judge name, student code, adjust scores
+						my $other_judge_name = $other_judge->first." ".$other_judge->last;
+						my $other_score = $other_entry_scores_count{$other_judge->id}{$entryid};
+						$other_score = 0 if $other_score == undef;
+						my $student_code;
+						foreach my $student (@panel_students) {
+							if ($student->entry == $entryid) {
+								$student_code = $student->code;
+							}
 						}
+						
+						# Create error message
+						$errs .= "Warning! Judge ".$other_judge_name." has ".$other_score
+						." scores for competitor ".$student_code." while you have ".$entry_scores{$entryid}{"count"}
+						."!  Please make sure you agree on the number of speeches for each competitor!<br>";					
 					}
-					
-					# Create error message
-					$errs .= "Warning! Judge ".$other_judge_name." has ".$other_score
-					." scores for competitor ".$student_code." while you have ".$entry_scores{$entryid}{"count"}
-					."!  Please make sure you agree on the number of speeches for each competitor!<br>";					
 				}
 			}
 		}


### PR DESCRIPTION
This adds a simple check for Congress ballots that produces an error message if you have a different number of speeches recorded for any competitor compared to the other judges in the round.  The error message appears but does not stop submission, just in case there is something funny going on.

If this works, it would be great if we could get this change incorporated this week.  We have a big tournament this weekend that would be nice to use this in.  Sorry for the late push.