### PR TITLE
Fix 404 from Nuisance Fines to Tournament Dates

### DIFF
--- a/web/setup/money/fines.mhtml
+++ b/web/setup/money/fines.mhtml
@@ -167,7 +167,7 @@
 
 		<p class="centeralign semibold">
 			To change the date after which nuisance fines apply, go to:
-			<a class="inline" href="/setup/date/date.mhtml">Setup &rarr; Dates & Deadlines</a>
+			<a class="inline" href="/setup/tourn/dates.mhtml">Setup &rarr; Dates & Deadlines</a>
 		</p>
 
 	</div>


### PR DESCRIPTION
We get a 404 from the link at the bottom of Nuisance Fines