### PR TITLE
CSS Cleanup

### DIFF
--- a/web/lib/css/tabroom.css
+++ b/web/lib/css/tabroom.css
@@ -5567,8 +5567,8 @@ li.smallish {
   background : url('/lib/images/chosen-sprite.png') -42px 1px no-repeat;
   font-size  : 1px;
 }
-.chosen-container-multi .chosen-choices li.search-choice .search-choice-close : hover {
-  background-position                                                         : -42px -10px;
+.chosen-container-multi .chosen-choices li.search-choice .search-choice-close :hover {
+  background-position : -42px -10px;
 }
 .chosen-container-multi .chosen-choices li.search-choice-disabled {
   padding-right    : 5px;


### PR DESCRIPTION
Very minor updates:
* Remove useless units on zero values.
* Remove duplicate values.
* Remove invalid Mozilla internal properties.
* Use shorthand on margin and padding in some places.
* Add a few default font families - more needed here. 