### PR TITLE
Prevent width settings for hidden inputs, causing zero width.

### DIFF
--- a/web/lib/javascript/tabroom.js
+++ b/web/lib/javascript/tabroom.js
@@ -1169,12 +1169,7 @@ var waitForFinalEvent = (function () {
 function resizeAll() {
 
 	$('input[type=text], input[type=email], input[type=tel], input[type=date], input[type=time], input[type=url]').each(function(){
-		if (
-			$(this).parent().is("td")
-			|| $(this).parent().is("th")
-			|| $(this).parent().is("label")
-		) {
-		} else {
+		if ($(this).is(':visible') && !['TD','TH','LABEL'].includes($(this).parent()[0].tagName)) {
 			$(this).width($(this).parent().width()-10);
 		}
 	});


### PR DESCRIPTION
Ran into the text input box being zero-width, which appears to be because the width is set when the element is hidden.
I think this is the appropriate fix.

<img width="769" alt="Screen Shot 2022-03-19 at 8 19 52 AM" src="https://user-images.githubusercontent.com/1731657/160239929-b71dcb7a-2f11-45fe-baf6-199a194b8a55.png">
<img width="1055" alt="Screen Shot 2022-03-19 at 8 18 17 AM" src="https://user-images.githubusercontent.com/1731657/160239930-f8dfa7ed-2168-4212-b3f5-e27183dbd01c.png">
