### PR TITLE
fix: Prevent browser autocomplete from interfering with time picker

### DIFF
--- a/web/funclib/timepicker.mas
+++ b/web/funclib/timepicker.mas
@@ -25,13 +25,14 @@
 	 </script>
 
 	<input
-		class       = "notfirst"
-		id          = "<% $name %>"
-		size        = "<% $size %>"
-		placeholder = "<% $placeholder %>"
-		type        = "text"
-		name        = "<% $name %>"
-		value       = "<% $time ? Tab::pickertime($time) : $value ? $value : Tab::pickertime($default) %>"
+		autocomplete = "off"
+		class        = "notfirst"
+		id           = "<% $name %>"
+		size         = "<% $size %>"
+		placeholder  = "<% $placeholder %>"
+		type         = "text"
+		name         = "<% $name %>"
+		value        = "<% $time ? Tab::pickertime($time) : $value ? $value : Tab::pickertime($default) %>"
 %		if ($target_id) {
 			target_id     = "<% $target_id %>"
 			setting_name  = "<% $setting_name %>"


### PR DESCRIPTION
Add `autocomplete="off"` to the timepicker logic to prevent the below:
![tabroom-timepicker-autocomplete-issue](https://user-images.githubusercontent.com/1731657/200120929-2b735c93-2241-4731-be46-aa845f6c0cb7.png)

