### PR TITLE
Fix circuit select UI

### DIFF
--- a/web/user/tourn/circuit.mhtml
+++ b/web/user/tourn/circuit.mhtml
@@ -110,84 +110,88 @@
 
 %		if (@circuits) { 
 			<h4>Circuits you administer</h4>
-%		}
 
-		<div class="full nospace">
-%		foreach my $circuit (sort {$a->name cmp $b->name} @circuits) {
+			<div class="full nospace">
+%			foreach my $circuit (sort {$a->name cmp $b->name} @circuits) {
 
 %			next if $done_already{$circuit->id}++;
 
-			<label for="<% $circuit->id %>">
-				<span class="pagehalf hover odd ltborderbottom marno middle">
-					<span class="tenth centeralign">
-						<input
-							type = "checkbox"
-							name = "<% $circuit->id %>"
-							id   = "<% $circuit->id %>"
-							<% $request->{"circuits"}{$circuit->id} ? "checked" : "" %>
-						>
-					</span>
-					<span class="fourfifths padno">
-						<% $circuit->name %>
-					</span>
+				<label for="<% $circuit->id %>">
+					<span class="pagehalf hover odd ltborderbottom marno middle">
+						<span class="tenth centeralign">
+							<input
+								type = "checkbox"
+								name = "<% $circuit->id %>"
+								id   = "<% $circuit->id %>"
+								<% $request->{"circuits"}{$circuit->id} ? "checked" : "" %>
+							>
+						</span>
+						<span class="fourfifths padno">
+							<% $circuit->name %>
+						</span>
 
-					<span class="tenth centeralign">
-						<% $circuit->state ? $circuit->state : $circuit->country %>
+						<span class="tenth centeralign">
+							<% $circuit->state ? $circuit->state : $circuit->country %>
+						</span>
 					</span>
+				</label>
+%			}
+			</div>
+
+			<div class="libl pagefull rightalign padleft">
+				<span class="third centeralign">
+					<input
+						type  = "submit"
+						value = "Next:  Tournament Location"
+					>
 				</span>
-			</label>
+			</div>
 %		}
-		</div>
-
-		<div class="libl pagefull rightalign padleft">
-			<span class="third centeralign">
-				<input
-					type  = "submit"
-					value = "Next:  Tournament Location"
-				>
-			</span>
-		</div>
 
 %		if (@tourn_circuits) { 
 			<h4>Circuits you've managed tournaments in</h4>
-%		}
 
-		<div class="full nospace">
-%		foreach my $circuit (sort {$a->name cmp $b->name} @tourn_circuits) {
-%			next if $done_already{$circuit->id}++;
+			<div class="full nospace">
+%			foreach my $circuit (sort {$a->name cmp $b->name} @tourn_circuits) {
+%				next if $done_already{$circuit->id}++;
 
-			<label for="<% $circuit->id %>">
-				<span class="pagehalf hover odd ltborderbottom marno middle">
-					<span class="tenth centeralign">
-						<input
-							type = "checkbox"
-							name = "<% $circuit->id %>"
-							id   = "<% $circuit->id %>"
-							<% $request->{"circuits"}{$circuit->id} ? "checked" : "" %>
-						>
-					</span>
-					<span class="fourfifths padno">
-						<% $circuit->name %>
-					</span>
+				<label for="<% $circuit->id %>">
+					<span class="pagehalf hover odd ltborderbottom marno middle">
+						<span class="tenth centeralign">
+							<input
+								type = "checkbox"
+								name = "<% $circuit->id %>"
+								id   = "<% $circuit->id %>"
+								<% $request->{"circuits"}{$circuit->id} ? "checked" : "" %>
+							>
+						</span>
+						<span class="fourfifths padno">
+							<% $circuit->name %>
+						</span>
 
-					<span class="tenth centeralign">
-						<% $circuit->state ? $circuit->state : $circuit->country %>
+						<span class="tenth centeralign">
+							<% $circuit->state ? $circuit->state : $circuit->country %>
+						</span>
 					</span>
+				</label>
+%			}
+			</div>
+
+			<div class="liblrow rightalign">
+				<span class="third centeralign">
+					<input
+						type  = "submit"
+						value = "Next:  Tournament Location"
+					>
 				</span>
-			</label>
+			</div>
 %		}
-		</div>
-
-		<div class="liblrow rightalign">
-			<span class="third centeralign">
-				<input
-					type  = "submit"
-					value = "Next:  Tournament Location"
-				>
-			</span>
-		</div>
-
-		<h4>Other circuits</h4>
+		
+%		if (@circuits || @tourn_circuits) { 
+			<h4>Other circuits</h4>
+%		} else {
+			<h4>Circuits</h4>
+% 	}
 
 		<div class="full nospace">
 %		foreach my $circuit (sort {$a->name cmp $b->name} @all_circuits) {

--- a/web/user/tourn/circuit.mhtml
+++ b/web/user/tourn/circuit.mhtml
@@ -177,7 +177,7 @@
 %			}
 			</div>
 
-			<div class="liblrow rightalign">
+			<div class="libl pagefull rightalign padleft">
 				<span class="third centeralign">
 					<input
 						type  = "submit"
@@ -223,7 +223,7 @@
 			<span class="third centeralign">
 				<input
 					type  = "submit"
-					value = "Next:  Tournament Host Site"
+					value = "Next:  Tournament Location"
 				>
 			</span>
 		</div>


### PR DESCRIPTION
Previously, the header for circuits that the current user administers or has previously held a tournament in were only shown on the circuit selection screen if at least one existed. However, the next button under the table was always shown. This PR fixes this so it only shows the buttons under the table when the table itself is shown.
It also fixes a couple inconsistencies in the styling of the buttons and the text they display

Before:
![image](https://user-images.githubusercontent.com/60764137/203664723-ec66f652-8194-490d-a551-048932e2b4dc.png)

After:
![image](https://user-images.githubusercontent.com/60764137/203664563-3fbb7af6-c56e-458f-9939-1b7c6d01cad2.png)