### PR TITLE
fix: Tiebreaks - Make dropdown wording match display wording.

### DIFF
--- a/web/setup/rules/tiebreak_edit.mas
+++ b/web/setup/rules/tiebreak_edit.mas
@@ -14,7 +14,7 @@
         "ranks", "winloss", "reciprocals", "points", "ballots", "judgepref",
 		"seed", "opp_seed", "opp_ranks", "opp_wins", "opp_points", "opp_ballots", "headtohead",
 		"judgevar", "judgevar2", "point_diff",
-		"chair_ranks", "non_chair_ranks", "congress_speech", "po_points", "best_po", 
+		"chair_ranks", "non_chair_ranks", "congress_speech", "po_points", "best_po",
 		"downs", "rounds", "losses", "num_ballots",
 		"student_nominee", "student_rank", "student_recip", "entry_vote_one", "entry_vote_all",
 		"preponderance", "three_way_point", "3way_pts_worst",
@@ -251,7 +251,7 @@
 						>None</option>
 					<option value="1"
 						<% $tiebreak && $tiebreak->highlow == 1 ? "selected" : "" %>
-						>High &amp; Low</option>
+						>Best &amp; Worst</option>
 					<option value="3"
 						<% $tiebreak && $tiebreak->highlow == 3 ? "selected" : "" %>
 						>Best</option>


### PR DESCRIPTION
<img width="1054" alt="Tiebreak Language Consistentcy" src="https://user-images.githubusercontent.com/1731657/216777924-79d12d22-c8fd-4a77-ad20-64216514a014.png">
