### PR TITLE
fix: Schedule - Ordering of Slots with  Same Start Times

### DIFF
--- a/web/setup/schedule/event.mhtml
+++ b/web/setup/schedule/event.mhtml
@@ -131,7 +131,7 @@
 		where timeslot.tourn = ?
 			and tourn.id = timeslot.tourn
 		$timeslot_limit
-		order by timeslot.start
+		order by timeslot.start, timeslot.name
 	");
 
 	$timeslot_sth->execute($tourn->id);


### PR DESCRIPTION
The ordering of time slots with the same start time is arbitrary. Adding sorting by timeslot naming for consistency.

<img width="1066" alt="schedule-timeslot-order-1" src="https://user-images.githubusercontent.com/1731657/216779892-81344962-3453-466b-b52c-e9437c2a0083.png">
<img width="1082" alt="schedule-timeslot-order-2" src="https://user-images.githubusercontent.com/1731657/216779893-00bacf6a-402c-4d17-b4dd-95abdeb44d58.png">
