### PR TITLE
Add descriptive titles for commonly-accessed pages

### DIFF
--- a/web/index/tourn/fields.mhtml
+++ b/web/index/tourn/fields.mhtml
@@ -339,3 +339,7 @@
 		</div>
 	</div>
 
+# At this point, tourn will be defined and should be used to grab the website title
+<title>
+Entries <% $event->name ? "- {$event->name} " : "" %>-<% $tourn->name %> - Tabroom.com
+</title>

--- a/web/index/tourn/index.mhtml
+++ b/web/index/tourn/index.mhtml
@@ -6,13 +6,6 @@
 	$webname    => undef
 </%args>
 
-# Apply a title specific to the tournament
-<title>
-<%
-    $webname ? $$webname : ""
-%> Tabroom.com
-</title>
-
 <%init>
 
 	my $key = $tourn_id."-".$site_id."-".$webpage_id;

--- a/web/index/tourn/index.mhtml
+++ b/web/index/tourn/index.mhtml
@@ -254,3 +254,7 @@
 		whoami         => "index"
 	&>
 
+# At this point, tourn will be defined and should be used to grab the website title
+<title>
+<% $tourn ?  $tourn->name : "" %> Tabroom.com
+</title>

--- a/web/index/tourn/index.mhtml
+++ b/web/index/tourn/index.mhtml
@@ -5,6 +5,14 @@
 	$person     => undef
 	$webname    => undef
 </%args>
+
+# Apply a title specific to the tournament
+<title>
+<%
+    $webname ? $$webname : ""
+%> Tabroom.com
+</title>
+
 <%init>
 
 	my $key = $tourn_id."-".$site_id."-".$webpage_id;

--- a/web/index/tourn/judges.mhtml
+++ b/web/index/tourn/judges.mhtml
@@ -341,3 +341,7 @@
 		tourn    => $tourn
 	&>
 
+# At this point, tourn will be defined and should be used to grab the website title
+<title>
+Judges - <% $tourn ?  $tourn->name : "" %> - Tabroom.com
+</title>

--- a/web/index/tourn/paradigm.mhtml
+++ b/web/index/tourn/paradigm.mhtml
@@ -101,3 +101,6 @@
 		tourn       => $tourn
 	&>
 
+<title>
+Paradigm - <% $judge ? $judge->first." ".$judge->last : "" %> - Tabroom.com
+</title>

--- a/web/index/tourn/postings/cleared.mhtml
+++ b/web/index/tourn/postings/cleared.mhtml
@@ -127,3 +127,7 @@
 %		}
 		</div>
 	</div>
+
+<title>
+Pairings - <% $event->name %> - Advancing Entries - <% $tourn->name %> - Tabroom.com
+</title>

--- a/web/index/tourn/postings/entry_record.mhtml
+++ b/web/index/tourn/postings/entry_record.mhtml
@@ -400,3 +400,6 @@
 %		}
 	</div>
 
+<title>
+Entry Record - <% $entry->code %> - <% $event->name %> - <% $tourn->name %> - Tabroom.com
+</title>

--- a/web/index/tourn/postings/index.mhtml
+++ b/web/index/tourn/postings/index.mhtml
@@ -141,3 +141,7 @@
 		round_id => $round_id
 	&>
 
+# At this point, tourn will be defined and should be used to grab the website title
+<title>
+Pairings - <% $tourn ?  $tourn->name : "" %> - Tabroom.com
+</title>

--- a/web/index/tourn/postings/round.mhtml
+++ b/web/index/tourn/postings/round.mhtml
@@ -159,3 +159,7 @@
 
 	</div>
 
+# At this point, tourn will be defined and should be used to grab the website title
+<title>
+Pairings - <% $event->name %> - <% $round->realname %> - <% $tourn ?  $tourn->name : "" %> - Tabroom.com
+</title>

--- a/web/index/tourn/results/bracket.mhtml
+++ b/web/index/tourn/results/bracket.mhtml
@@ -23,4 +23,6 @@
 		public     => 1
 	&>
 
-
+<title>
+Results - <% $event->name %> - Bracket - <% $tourn->name %> - Tabroom.com
+</title>

--- a/web/index/tourn/results/bracket_wudc.mhtml
+++ b/web/index/tourn/results/bracket_wudc.mhtml
@@ -265,3 +265,7 @@
 
 
 	</div>
+
+<title>
+Results - <% $event->name %> - Bracket - <% $tourn->name %> - Tabroom.com
+</title>

--- a/web/index/tourn/results/debate_cumesheet.mhtml
+++ b/web/index/tourn/results/debate_cumesheet.mhtml
@@ -578,3 +578,8 @@
 		</table>
 
 	</div>
+
+# Some kids will get the giggles when this cuts off right before "e Sheet". So it goes
+<title>
+Results - <% $event->name %> - Cume Sheet - <% $tourn->name %> - Tabroom.com
+</title>

--- a/web/index/tourn/results/event_results.mhtml
+++ b/web/index/tourn/results/event_results.mhtml
@@ -64,3 +64,6 @@
 
 	</div>
 
+<title>
+Results - <% $event->name %> - <% $result_set->label %> - <% $tourn->name %> - Tabroom.com
+</title>

--- a/web/index/tourn/results/index.mhtml
+++ b/web/index/tourn/results/index.mhtml
@@ -87,3 +87,6 @@
 			result_set_id => $result_set_id
 	&>
 
+<title>
+Results - <% $tourn->name %> - Tabroom.com
+</title>

--- a/web/index/tourn/results/ranked_list.mhtml
+++ b/web/index/tourn/results/ranked_list.mhtml
@@ -253,4 +253,6 @@
 
 	</div>
 
-
+<title>
+Results - <% $event->name %> - Prelim Records - <% $tourn->name %> - Tabroom.com
+</title>

--- a/web/index/tourn/results/round_results.mhtml
+++ b/web/index/tourn/results/round_results.mhtml
@@ -96,3 +96,6 @@
 
 	</div>
 
+<title>
+Results - <% $event->name %> - <% $round->realname %> - <% $tourn->name %> - Tabroom.com
+</title>


### PR DESCRIPTION
See Issue #34 for design details.

This adds descriptive titles to common pages to support indexing (easy to find a page from your web history) and make it easier to find the tab you're looking for.

Also gosh I hope commits get squashed. Sorry!