### PR TITLE
Use explicit element instead of $(this)

### DIFF
--- a/web/tabbing/status/status.mhtml
+++ b/web/tabbing/status/status.mhtml
@@ -598,18 +598,18 @@
 			var panelCounts = {};
 			var startCounts = {};
 
-			$(".start").each( index => {
-				var panelId = $(this).attr('panel');
+			$(".start").each( (index, elem) => {
+				var panelId = $(elem).attr('panel');
 
 				if (panelCounts[panelId]) {
 				} else {
 					panelCounts[panelId] = 0;
 				}
 
-				if ($(this).attr('property_name') == 1) {
+				if ($(elem).attr('property_name') == 1) {
 					panelCounts[panelId]++;
 				}
-				if ($(this).attr('bye') == 1) {
+				if ($(elem).attr('bye') == 1) {
 					panelCounts[panelId] += 10;
 				}
 			});
@@ -632,9 +632,9 @@
 			var panelRatio = {};
 			var panelBye = {};
 
-			$(".container").each( index => {
+			$(".container").each( (index, elem) => {
 
-				var panelId = $(this).attr('panel');
+				var panelId = $(elem).attr('panel');
 				panelRatio[panelId] = $("#"+panelId+"_bodies").attr('total');
 
 				if (panelCounts[panelId]) {
@@ -642,11 +642,11 @@
 					panelCounts[panelId] = 0;
 				}
 
-				if ($(this).attr('property_name') == 1) {
+				if ($(elem).attr('property_name') == 1) {
 					panelCounts[panelId]++;
 				}
 
-				if ($(this).attr('bye') == 1) {
+				if ($(elem).attr('bye') == 1) {
 					panelCounts[panelId] = panelRatio[panelId];
 					panelRatio[panelId] = .5;
 					panelBye[panelId] = 1;
@@ -678,8 +678,8 @@
 			var judgeStarts = {};
 			var judgeRatio = {};
 
-			$(".start").each( index => {
-				var panelId = $(this).attr('panel');
+			$(".start").each( (index, elem) => {
+				var panelId = $(elem).attr('panel');
 				judgeRatio[panelId] = $("#"+panelId+"_bodies").attr('judges');
 
 				if (judgeStarts[panelId]) {
@@ -687,7 +687,7 @@
 					judgeStarts[panelId] = 0;
 				}
 
-				if ($(this).attr('property_name') == 1) {
+				if ($(elem).attr('property_name') == 1) {
 					judgeStarts[panelId]++;
 				}
 			});
@@ -712,20 +712,20 @@
 		function countDone() {
 			var panelCounts = {};
 
-			$(".done").each( index => {
+			$(".done").each( (index, elem) => {
 
-				var panelId = $(this).attr('panel');
+				var panelId = $(elem).attr('panel');
 
 				if (panelCounts[panelId]) {
 				} else {
 					panelCounts[panelId] = 0;
 				}
 
-				if ($(this).attr('property_name') == 1) {
+				if ($(elem).attr('property_name') == 1) {
 					panelCounts[panelId]++;
 				}
 
-				if ($(this).attr('bye') == 1) {
+				if ($(elem).attr('bye') == 1) {
 					panelCounts[panelId] += 10;
 				}
 			});
@@ -760,8 +760,8 @@
 				}
 			}
 
-			$(".flightbutton").each(index => {
-				var flight = $(this).attr("flight");
+			$(".flightbutton").each((index, elem) => {
+				var flight = $(elem).attr("flight");
 				if ($("#flight_"+flight).attr("state") == 0) {
 					$(".flight_"+flight).addClass("hidden");
 				}


### PR DESCRIPTION
In an arrow funtion, `this` refers to the whole page rather then the more local value that JQuery's `.each` expects.  This switches to the two-arg version of `each` where the second arg is the current element.