### PR TITLE
Default Judges page to category _id of 0

### DIFF
--- a/web/index/tourn/judges.mhtml
+++ b/web/index/tourn/judges.mhtml
@@ -1,6 +1,6 @@
 <%args>
 	$tourn_id
-	$category_id => undef
+	$category_id => 0
 	$person      => undef
 </%args>
 <%init>


### PR DESCRIPTION
Closes #40 

The default value of `undef` causes some issues when used in comparison operators. Defaulting to 0 allows the splash page to render normally.