### PR TITLE
Fix printing room pools

### DIFF
--- a/web/setup/rooms/menu.mas
+++ b/web/setup/rooms/menu.mas
@@ -232,8 +232,8 @@
 				</a>
 
 				<a
-					class="blue full" 
-					href="/panel/room/rpools_print.mhtml"
+					class = "blue full" 
+					href  = "/panel/room/rpools_print.mhtml"
 				>
 					Print Room Pools
 				</a>

--- a/web/setup/rooms/menu.mas
+++ b/web/setup/rooms/menu.mas
@@ -231,8 +231,11 @@
 					Create New Room Pool
 				</a>
 
-				<a class="blue full" href="/panel/room/print_rpools.mhtml">
-					Print Pools
+				<a
+					class="blue full" 
+					href="/panel/room/rpools_print.mhtml"
+				>
+					Print Room Pools
 				</a>
 
 			</div>


### PR DESCRIPTION
The previous href was pointing to a page that no longer existed, this points it to the proper page.
(also formats to be similar to the rest of the page)