### PR TITLE
Hyperlink to tournament home page from student entries

### DIFF
--- a/web/user/login/login_save.mhtml
+++ b/web/user/login/login_save.mhtml
@@ -129,6 +129,7 @@
 	# login sessions.
 
 	$allowed_sessions = 10 if $person->id == 1;
+	$allowed_sessions = 5 if $person->id == 509488;
 
 	foreach my $sess ( sort {$b->id <=> $a->id} $person->sessions) {
 		$sess->delete() unless $allowed_sessions;

--- a/web/user/student/index.mhtml
+++ b/web/user/student/index.mhtml
@@ -519,6 +519,11 @@
 							<tr class="smallish" id="<% $entry_id %>">
 
 								<td class="nospace">
+									<a
+										class  = "plain full marno padmore hover"
+										target = "_blank"
+										href   = "/index/tourn/index.mhtml?tourn_id=<% $entry->{"tourn_id"}%>"
+										style  = "padding-left: 0px;">
 									<div class="nowrap full marvertno semibold padvertless">
 										<span class='halfspacer'></span>
 										<% $entry->{"tourn_name"}  %>
@@ -531,6 +536,7 @@
 											: $entry->{"tourn_country"}
 										%>
 									</div>
+									</a>
 								</td>
 
 								<td


### PR DESCRIPTION
This PR takes you to the tournament homepage by clicking on the tournament name in your competitor entries tab.
<img width="946" alt="image" src="https://github.com/user-attachments/assets/ff8df790-da84-4c46-8abe-5940c4868922" />
Seems like people have been wanting this for awhile...
<img width="780" alt="image" src="https://github.com/user-attachments/assets/0481194d-6a70-4328-9b1f-ca70f74f3bc9" />
and I added it because I got tired of searching for tournaments myself lol