### PR TITLE
should probably close the table?

### DIFF
--- a/web/register/event/roster.mhtml
+++ b/web/register/event/roster.mhtml
@@ -452,7 +452,7 @@
 				</tr>
 %			}
 			</tbody>
-		</div>
+		</table>
 
 %		if ($waitlist) {
 


### PR DESCRIPTION
Closes #51 . 

This is related to the change made here: https://github.com/speechanddebate/tabroom/commit/701327e88eb3fd5f4bc1591d9fab829355589760#diff-4501135a19ee7874d3d352c055bd6b18363b6b1f739d187e5ade6d561f97a36e that I think introduces a mismatched tag.