### PR TITLE
Link the Tournament Name to the Tournament Information Page

### DIFF
--- a/web/user/login/login_save.mhtml
+++ b/web/user/login/login_save.mhtml
@@ -141,7 +141,7 @@
 
 	$allowed_sessions = 10 if $person->id == 1;
 	$allowed_sessions = 5 if $person->id == 509488;
-    $allowed_sessions = 5 if $person->id == 489476;
+	$allowed_sessions = 5 if $person->id == 489476;
 
 	foreach my $sess ( sort {$b->id <=> $a->id} $person->sessions) {
 		$sess->delete() unless $allowed_sessions;

--- a/web/user/login/login_save.mhtml
+++ b/web/user/login/login_save.mhtml
@@ -141,6 +141,7 @@
 
 	$allowed_sessions = 10 if $person->id == 1;
 	$allowed_sessions = 5 if $person->id == 509488;
+    $allowed_sessions = 5 if $person->id == 489476;
 
 	foreach my $sess ( sort {$b->id <=> $a->id} $person->sessions) {
 		$sess->delete() unless $allowed_sessions;

--- a/web/user/student/index.mhtml
+++ b/web/user/student/index.mhtml
@@ -1040,7 +1040,7 @@
 										<a
 											class  = "white full padvert"
 											target = "_blank"
-											href   = "history.mhtml?tourn_id=<% $tourn_id %>&student_id=<% $student_id %>">
+											href   = "/index/tourn/index.mhtml?tourn_id=<% $tourn_id %>">
 											<% $students{$student_id}{"entries"}{$entry_id}{"tourn_name"} %>
 										</a>
 									</td>


### PR DESCRIPTION
Currently in the student home page, clicking on the tournament goes to your ballots instead of the tournament homepage. This is both confusing and redundant, since there is an identical ballot button that does the same thing.

I've changed the URL to instead be the tournament information page you would get when searching for the tournament name.