### PR TITLE
Make Tabroom CORS Compatible

### DIFF
--- a/web/lib/handler.pl
+++ b/web/lib/handler.pl
@@ -162,6 +162,14 @@ sub handler {
 		);
  	}
 
+    my $origin = $r->headers_in->{'Origin'};
+
+    if ($origin && $origin =~ m{^https?://[a-zA-Z0-9.-]+(:\d+)?$}) {
+        $r->headers_out->set('Access-Control-Allow-Origin' => $origin);
+        $r->headers_out->set('Access-Control-Allow-Credentials' => 'true');
+        $r->headers_out->set('Access-Control-Allow-Methods' => 'GET, POST, PUT, DELETE, OPTIONS');
+    }
+    
 	my $return = eval {
 		return $ah->handle_request($r);
 	};


### PR DESCRIPTION
Currently, Tabroom does not send any CORS-related headers based on the value of the `Origin` request header. This makes it impossible to make requests to Tabroom from external websites.

This PR adds the following response headers:
- Sends an `Access-Control-Allow-Origin` header set to the value of the `Origin` header (after sanitization, see below)
- Sets `Access-Control-Allow-Credentials` to `true`
- Sets `Access-Control-Allow-Methods` to `GET, POST, PUT, DELETE, OPTIONS`.
- Performs a sanitization check using RegEx to make sure that the value of `Origin` is a valid URL

The value of `Access-Control-Allow-Origin` matches the `Origin` header because you cannot send an `Access-Control-Allow-Origin` header with a wildcard while also allowing cookie-based authentication in `Access-Control-Allow-Credentials`. The workaround was to copy the `Origin` header.

Not tested.