### PR TITLE
feat: Add strikethrough for drops on double-entered list

### DIFF
--- a/web/register/reports/multiple_entries.mhtml
+++ b/web/register/reports/multiple_entries.mhtml
@@ -128,11 +128,11 @@
 </%perl>
 				<tr>
 
-					<td>
+					<td class="<% $entry->{dropped} ? 'strike' : '' %>">
 						<% $entry->{event} %>
 					</td>
 
-					<td>
+					<td class="<% $entry->{dropped} ? 'strike' : '' %>">
 						<a
 							class="white"
 							href="/register/entry/edit.mhtml?entry_id=<% $entry_id %>"
@@ -142,7 +142,7 @@
 						</a>
 					</td>
 
-					<td class="smallish">
+					<td class="smallish<% $entry->{dropped} ? ' strike' : '' %>">
 						<% $entry->{name} %>
 					</td>
 


### PR DESCRIPTION
Add strikethrough for dropped events in double entry list. Unable to verify this proposed fix, though it should create a presentation roughly like this:

<img width="817" height="107" alt="Image" src="https://github.com/user-attachments/assets/993776d4-c6cc-40ad-b2dd-19307f0b3368" />

Potentially fixes #75 